### PR TITLE
Update ecp get

### DIFF
--- a/.github/workflows/inference-workflow.yml
+++ b/.github/workflows/inference-workflow.yml
@@ -24,7 +24,7 @@ jobs:
       run: |
         wget https://download.pegasus.isi.edu/pegasus/ubuntu/dists/bionic/main/binary-amd64/pegasus_5.0.1-1+ubuntu18_amd64.deb
         sudo apt install ./pegasus_5.0.1-1+ubuntu18_amd64.deb
-    - run: sudo apt-get install *fftw3* intel-mkl*
+    - run: sudo apt-get install *fftw3* intel-mkl* libkrb5-dev libssl-dev
     - name: Install pycbc
       run: |
         python -m pip install --upgrade 'pip<22.0' setuptools

--- a/.github/workflows/mac-test.yml
+++ b/.github/workflows/mac-test.yml
@@ -17,7 +17,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - run: |
-        brew install fftw
+        brew install fftw openssl
         pip install --upgrade pip setuptools tox
     - name: run basic pycbc test suite
       run: |

--- a/.github/workflows/search-workflow.yml
+++ b/.github/workflows/search-workflow.yml
@@ -24,7 +24,7 @@ jobs:
       run: |
         wget https://download.pegasus.isi.edu/pegasus/ubuntu/dists/bionic/main/binary-amd64/pegasus_5.0.1-1+ubuntu18_amd64.deb
         sudo apt install ./pegasus_5.0.1-1+ubuntu18_amd64.deb
-    - run: sudo apt-get install *fftw3* intel-mkl*
+    - run: sudo apt-get install *fftw3* intel-mkl* libkrb5-dev libssl-dev
     - name: Install pycbc
       run: |
         python -m pip install --upgrade 'pip<22.0' setuptools

--- a/.github/workflows/tmpltbank-workflow.yml
+++ b/.github/workflows/tmpltbank-workflow.yml
@@ -24,7 +24,7 @@ jobs:
       run: |
         wget https://download.pegasus.isi.edu/pegasus/ubuntu/dists/bionic/main/binary-amd64/pegasus_5.0.1-1+ubuntu18_amd64.deb
         sudo apt install ./pegasus_5.0.1-1+ubuntu18_amd64.deb
-    - run: sudo apt-get install *fftw3* intel-mkl*
+    - run: sudo apt-get install *fftw3* intel-mkl* libkrb5-dev libssl-dev
     - name: Install pycbc
       run: |
         python -m pip install --upgrade 'pip<22.0' setuptools

--- a/.github/workflows/workflow-tests.yml
+++ b/.github/workflows/workflow-tests.yml
@@ -29,7 +29,7 @@ jobs:
       run: |
         wget https://download.pegasus.isi.edu/pegasus/ubuntu/dists/bionic/main/binary-amd64/pegasus_5.0.1-1+ubuntu18_amd64.deb
         sudo apt install ./pegasus_5.0.1-1+ubuntu18_amd64.deb
-    - run: sudo apt-get install *fftw3* intel-mkl*
+    - run: sudo apt-get install *fftw3* intel-mkl* libkrb5-dev libssl-dev
     - name: Install pycbc
       run: |
         python -m pip install --upgrade 'pip<22.0' setuptools

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ADD docker/etc/cvmfs/config-osg.opensciencegrid.org.conf /etc/cvmfs/config-osg.o
 RUN dnf -y install https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest.noarch.rpm && dnf -y install cvmfs cvmfs-config-default && dnf clean all && dnf makecache && \
     dnf -y groupinstall "Development Tools" \
                         "Scientific Support" && \
-    rpm -e --nodeps git perl-Git && dnf -y install @python38 rsync zlib-devel libpng-devel libjpeg-devel sqlite-devel openssl-devel fftw-libs-single fftw-devel fftw fftw-libs-long fftw-libs fftw-libs-double gsl gsl-devel hdf5 hdf5-devel python38-devel which osg-ca-certs && python3.8 -m pip install --upgrade pip setuptools wheel cython && python3.8 -m pip install mkl ipython jupyter jupyterhub jupyterlab lalsuite && \
+    rpm -e --nodeps git perl-Git && dnf -y install @python38 rsync zlib-devel libpng-devel libjpeg-devel sqlite-devel openssl-devel fftw-libs-single fftw-devel fftw fftw-libs-long fftw-libs fftw-libs-double gsl gsl-devel hdf5 hdf5-devel python38-devel swig which osg-ca-certs && python3.8 -m pip install --upgrade pip setuptools wheel cython && python3.8 -m pip install mkl ipython jupyter jupyterhub jupyterlab lalsuite && \
     dnf -y install https://repo.opensciencegrid.org/osg/3.5/el8/testing/x86_64/osg-wn-client-3.5-5.osg35.el8.noarch.rpm && dnf clean all
 
 # set up environment

--- a/pycbc/workflow/configuration.py
+++ b/pycbc/workflow/configuration.py
@@ -33,8 +33,6 @@ import shutil
 from shutil import which
 from urllib.parse import urlparse
 
-import ciecplib
-
 from pycbc.types.config import InterpolatingConfigParser
 
 
@@ -77,6 +75,9 @@ def resolve_url(url, directory=None, permissions=None, copy_to_cwd=True):
                 shutil.copy(u.path, filename)
 
     elif u.scheme == "http" or u.scheme == "https":
+        # FIXME: Move to top and make optional once 4001 functionality is
+        #        merged
+        import ciecplib
         with ciecplib.Session() as s:
             if u.netloc in ("git.ligo.org", "code.pycbc.phy.syr.edu"):
                 # authenticate with git.ligo.org using callback

--- a/tools/docker_build_dist.sh
+++ b/tools/docker_build_dist.sh
@@ -45,7 +45,7 @@ if [ "x${PYCBC_CONTAINER}" == "xpycbc_rhel_virtualenv" ]; then
   yum -y install openssl-devel
   yum -y install ligo-proxy-utils
   yum -y install python3-virtualenv
-  yum -y install hdf5-static libxml2-static zlib-static libstdc++-static cfitsio-static glibc-static fftw-static gsl-static --skip-broken
+  yum -y install hdf5-static libxml2-static zlib-static libstdc++-static cfitsio-static glibc-static swig fftw-static gsl-static --skip-broken
 
   CVMFS_PATH=/cvmfs/oasis.opensciencegrid.org/ligo/sw/pycbc/${ENV_OS}/virtualenv
   mkdir -p ${CVMFS_PATH}

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ passenv=LAL_DATA_PATH
 conda_deps=
     lalsuite
     openssl=1.1
+    m2crypto
 conda_channels=conda-forge
 
 # This test should run on almost anybody's environment


### PR DESCRIPTION
@duncanmmacleod This is what I think is needed to get 3997 working. It's mostly what you were already doing, but tox seems to be struggling to find openssl libraries if I don't install m2crypto outside of the conda env it will create. The ciecplib import also needs to be within the relevant function to avoid it becoming a requirement (as that module is imported in many places) ... The changes in 4001 provide a better way of doing that, but that can be flipped around as needed.